### PR TITLE
Change module name and copyright

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: format build
 .PHONY: build
 build: check-git deps ## Build thanos-sd-sidecar.
 	@echo ">> building thanos-sd-sidecar"
-	@GOBIN=$(GOBIN) go install github.com/saswatamcode/thanos-sd-sidecar
+	@GOBIN=$(GOBIN) go install github.com/thanos-community/thanos-sd-sidecar
 
 .PHONY: check-comments
 check-comments: ## Checks Go code comments if they have trailing period (excludes protobuffers and vendor files). Comments with more than 3 spaces at beginning are omitted from the check, example: '//    - foo'.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/saswatamcode/thanos-sd-sidecar
+module github.com/thanos-community/thanos-sd-sidecar
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) Saswata Mukherjee @saswatamcode
+// Copyright (c) Thanos Contributors
 // Licensed under the Apache License 2.0.
 
 package main
@@ -17,9 +17,9 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/run"
 	"github.com/pkg/errors"
-	"github.com/saswatamcode/thanos-sd-sidecar/pkg/discovery"
-	"github.com/saswatamcode/thanos-sd-sidecar/pkg/extkingpin"
-	"github.com/saswatamcode/thanos-sd-sidecar/pkg/version"
+	"github.com/thanos-community/thanos-sd-sidecar/pkg/discovery"
+	"github.com/thanos-community/thanos-sd-sidecar/pkg/extkingpin"
+	"github.com/thanos-community/thanos-sd-sidecar/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -1,4 +1,4 @@
-// Copyright (c) Saswata Mukherjee @saswatamcode
+// Copyright (c) Thanos Contributors
 // Licensed under the Apache License 2.0.
 
 package discovery

--- a/pkg/extkingpin/extkingpin.go
+++ b/pkg/extkingpin/extkingpin.go
@@ -1,4 +1,4 @@
-// Copyright (c) Saswata Mukherjee @saswatamcode
+// Copyright (c) Thanos Contributors
 // Licensed under the Apache License 2.0.
 
 // Taken from Thanos project.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
-// Copyright (c) Saswata Mukherjee @saswatamcode
+// Copyright (c) Thanos Contributors
 // Licensed under the Apache License 2.0.
 
 package version
 
 // Version returns 'thanos-sd-sidecar' version.
-const Version = "v0.0.1"
+const Version = "v0.0.1-dev"

--- a/scripts/copyright/copyright.go
+++ b/scripts/copyright/copyright.go
@@ -1,4 +1,4 @@
-// Copyright (c) Saswata Mukherjee @saswatamcode
+// Copyright (c) Thanos Contributors
 // Licensed under the Apache License 2.0.
 
 package main
@@ -14,7 +14,7 @@ import (
 
 var (
 	// license compatible for Go and Proto files.
-	license = []byte(`// Copyright (c) Saswata Mukherjee @saswatamcode
+	license = []byte(`// Copyright (c) Thanos Contributors
 // Licensed under the Apache License 2.0.
 
 `)


### PR DESCRIPTION
This PR changes the name of module from `github.com/saswatamcode/thanos-sd-sidecar` to `github.com/thanos-community/thanos-sd-sidecar`.